### PR TITLE
fix: dralia-1-fix2: Error: Resource not accessible by integration

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,3 +1,8 @@
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 name: Auto Tag Main Branch
 
 on:


### PR DESCRIPTION
GitHub token used by the workflow does not have permission to push, create tags, or write to the repo